### PR TITLE
Fixing icmd and and package_name being empty

### DIFF
--- a/internal/data/state.yml
+++ b/internal/data/state.yml
@@ -1,5 +1,7 @@
 device:
-  current: 0
+  current: 1
   devices:
   - ip: localhost
     port: 4444
+  - ip: 192.168.0.34
+    port: 22

--- a/internal/data/state.yml
+++ b/internal/data/state.yml
@@ -1,7 +1,5 @@
 device:
-  current: 1
+  current: 0
   devices:
   - ip: localhost
     port: 4444
-  - ip: 192.168.0.34
-    port: 22

--- a/internal/tools/generator
+++ b/internal/tools/generator
@@ -10,6 +10,8 @@ generate()
 
     eval $(DGEN_DEBUG=${DGEN_DEBUG} TARG_SIM=${simtarg} python3 $DRAGONBUILD/DragonGenerator.py)
 
+    source ./.dragon/env/variables
+
     export TWEAK_NAME=$package_name
     export INSTALL_CMD=$install_command
 }


### PR DESCRIPTION
I am fixing https://github.com/DragonBuild/dragon/issues/56 
More code in https://github.com/DragonBuild/DragonGen

Pretty much diverts variables to an env file sourced by the generator file in tools allowing install_cmd to be populated and therefore sent to the device on the package install.