### PR TITLE
Minor docs update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-copyright (c) 2020-2022 cynder
+copyright (c) 2020-2023 cynder
 
 dragon license version 1
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,4 @@
 # Minimal makefile for Sphinx documentation
-#
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
@@ -15,6 +14,6 @@ help:
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+# "make mode" option. $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==4.1.2
-sphinx_rtd_theme==0.5.2
-furo==2021.8.17b43
+sphinx<6.0.0
+sphinx_rtd_theme<=2.0.0
+furo==2022.12.7

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -3,9 +3,11 @@
     color: white !important;
     text-decoration: none !important;
 }
+
 .sidebar-drawer {
     width: calc(41% - 26em);
 }
+
 tbody tr:first-of-type td {
     font-weight: 700;
     padding-bottom: .5em;

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,7 +1,7 @@
 Commands
 ---------------------
 
-Running ``dragon`` without any arguments will list available commands, many of which have multiple aliases
+Running ``dragon`` without any arguments will list available commands, many of which have multiple aliases.
 
 You can combine most commands to do multiple actions with one command.
 
@@ -53,7 +53,7 @@ Respringing a device
 
 Running a command on the device
 *********************
-``dragon dr <commands>`` or ``dragon devicerun <commands>`` will execute anything after the command on the device (don't use quotes)
+``dragon dr <commands>`` or ``dragon devicerun <commands>`` will execute anything after the command on the current device (i.e. current installation target) [don't use quotes]
 
 
 Installing any deb on the device

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -1,9 +1,7 @@
 Commands
 ---------------------
 
-Running ``dragon`` without any arguments will list commands
-
-Many commands have multiple aliases
+Running ``dragon`` without any arguments will list available commands, many of which have multiple aliases
 
 You can combine most commands to do multiple actions with one command.
 
@@ -14,15 +12,13 @@ Packaging Commands
 Creating a new project/module
 *********************
 
-``dragon n``, ``dragon new``, ``dragon nic``, ``dragon edit``, or ``dragon create``
-
-Opens the Project Editor
+``dragon n``, ``dragon new``, ``dragon nic``, ``dragon edit``, or ``dragon create`` will open the Project Editor
 
 
 Building a package
 *********************
 
-``dragon b``, ``dragon build``, or ``dragon make``
+``dragon b``, ``dragon build``, or ``dragon make`` builds a package
 
 
 Clean Building a package
@@ -39,7 +35,7 @@ Device Commands
 Setting up a device
 *********************
 
-``dragon s`` or ``dragon device`` Can be used to set up an installation target
+``dragon s`` or ``dragon device`` will set up an installation target
 
 
 Installing a package
@@ -52,21 +48,21 @@ Combine it with the build command, or use ``dragon do`` to build and install a p
 Respringing a device
 *********************
 
-``dragon rs`` or ``dragon respring`` will respring the current device
+``dragon rs`` or ``dragon respring`` will respring the current device (i.e. current installation target)
 
 
 Running a command on the device
 *********************
-``dragon dr <commands>`` or ``dragon devicerun`` will execute anything after the command on the device (don't use quotes)
+``dragon dr <commands>`` or ``dragon devicerun <commands>`` will execute anything after the command on the device (don't use quotes)
 
 
 Installing any deb on the device
 *********************
 
-``dragon sn <file>`` or ``dragon send <file>`` anywhere on your drive, where <file> is a ``.deb``, will install that deb on your device.
+``dragon sn <file>`` or ``dragon send <file>`` will install a ``.deb`` anywhere on your drive to the current device (i.e. current installation target)
 
 
 Building and installing to the iOS Simulator
 *********************
 
-Adding the ``sim`` command to a set of commands targets the simulator, and if added to an ``install`` command, will install it to the iOS simulator
+Adding the ``sim`` command to a set of commands targets the simulator. If added to an ``install`` command, it will install the specified deb to the iOS simulator

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -22,10 +22,10 @@ Opens the Project Editor
 Building a package
 *********************
 
-``dragon b``, ``dragon build``, or ``dragon make`` 
+``dragon b``, ``dragon build``, or ``dragon make``
 
 
-Clean Building a package 
+Clean Building a package
 *********************
 
 ``dragon c`` or ``dragon clean`` will clean the 'build cache'
@@ -33,29 +33,29 @@ Clean Building a package
 Combine it with the build command to run a clean build (e.g. ``dragon c b``)
 
 
-Device Commands 
+Device Commands
 =====================
 
-Setting up a device 
+Setting up a device
 *********************
 
-``dragon s`` or ``dragon device`` Can be used to set up an installation target 
+``dragon s`` or ``dragon device`` Can be used to set up an installation target
 
 
 Installing a package
 *********************
 
-``dragon i`` or ``dragon install`` installs a package 
+``dragon i`` or ``dragon install`` installs a package
 
-Combine it with the build command, or use ``dragon do`` to build and install a package 
+Combine it with the build command, or use ``dragon do`` to build and install a package
 
-Respringing a device 
+Respringing a device
 *********************
 
-``dragon rs`` or ``dragon respring`` will respring the current device 
+``dragon rs`` or ``dragon respring`` will respring the current device
 
 
-Running a command on the device 
+Running a command on the device
 *********************
 ``dragon dr <commands>`` or ``dragon devicerun`` will execute anything after the command on the device (don't use quotes)
 
@@ -63,7 +63,7 @@ Running a command on the device
 Installing any deb on the device
 *********************
 
-``dragon sn <file>`` or ``dragon send <file>`` anywhere on your drive, where <file> is a ``.deb``, will install that deb on your device. 
+``dragon sn <file>`` or ``dragon send <file>`` anywhere on your drive, where <file> is a ``.deb``, will install that deb on your device.
 
 
 Building and installing to the iOS Simulator

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -70,4 +70,3 @@ Building and installing to the iOS Simulator
 *********************
 
 Adding the ``sim`` command to a set of commands targets the simulator, and if added to an ``install`` command, will install it to the iOS simulator
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full
@@ -10,19 +12,18 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
-import sys
+import os, sys
 
 sys.path.insert(0, os.path.abspath('../../'))
 
 # -- Project information -----------------------------------------------------
 
 project = 'dragon'
-copyright = '2022, cynder'
+copyright = '2023, cynder'
 author = 'cynder'
 
 # The full version, including alpha/beta/rc tags
-release = '1.6.4'
+release = '1.6.9'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/dragonmake.rst
+++ b/docs/source/dragonmake.rst
@@ -179,9 +179,9 @@ Types
 
 Tweak bundle filters
 ^^^^^^^^^^^^^^^^^^^^^
-Bundle filters tell MobileSubstrate what processes to inject your tweak into.
+Bundle filters tell MobileSubstrate (or whatever injection system your jailbreak uses) what processes to inject your tweak into.
 
-dragon supports the standard theos format, but allows specifying the values in the `DragonMake`, if you want.
+dragon supports the standard Theos format, but allows specifying the values in the `DragonMake`, if you want.
 
 .. code-block:: YAML
 

--- a/docs/source/dragonmake.rst
+++ b/docs/source/dragonmake.rst
@@ -5,15 +5,15 @@ Intead of splitting up build instructions among a ton of 'Makefile's, dragon bui
 
 DragonMake files use YAML syntax.
 
-.. code-block:: YAML 
-   
+.. code-block:: YAML
+
    name: DemoTweak
-   id: me.krit.dragondemo
+   id: me.cynder.dragondemo
    depends: mobilesubstrate
    architecture: iphoneos-arm
    description: Demo Tweak
-   author: krit
-   section: Tweaks 
+   author: cynder
+   section: Tweaks
 
    DemoTweak:
      type: tweak
@@ -24,20 +24,20 @@ DragonMake files use YAML syntax.
        - DemoTweak.x
 
 
-The Project 
+The Project
 *********************
 
 The full `DragonMake` represents the "Project", which contains one or more "Modules" (tweaks, prefs, etc).
 
-.. code-block:: YAML 
-   
+.. code-block:: YAML
+
    name: DemoTweak
-   id: me.krit.dragondemo
+   id: me.cynder.dragondemo
    depends: mobilesubstrate
    architecture: iphoneos-arm
    description: Demo Tweak
-   author: krit
-   section: Tweaks 
+   author: cynder
+   section: Tweaks
 
 Variables
 =====================
@@ -58,7 +58,7 @@ Variables
 `control` Variables
 =====================
 
-If your project already has a `control` file you don't need to worry about these. 
+If your project already has a `control` file you don't need to worry about these.
 
 .. list-table::
    :widths: 5 1 10
@@ -68,7 +68,7 @@ If your project already has a `control` file you don't need to worry about these
      - Description
    * - id
      - String
-     - Bundle ID (e.g. me.krit.demotweak) for the Project
+     - Bundle ID (e.g. me.cynder.demotweak) for the Project
    * - author
      - String
      - Author of the project. Current account's username will be used if none is provided
@@ -97,15 +97,15 @@ Debian Package Script Variables
 
 Lists of commands can be specified with `preinst:`, `postinst:`, `prerm:` and/or `postrm:` to create packaging scripts included in the binary.
 
-.. code-block:: YAML 
-   
+.. code-block:: YAML
+
    name: DemoTweak
-   id: me.krit.dragondemo
+   id: me.cynder.dragondemo
    depends: mobilesubstrate
    architecture: iphoneos-arm
    description: Demo Tweak
-   author: krit
-   section: Tweaks 
+   author: cynder
+   section: Tweaks
    # This will run on the device after installation
    postinst:
      - echo "Hello from dragon!"
@@ -117,7 +117,7 @@ Modules in the `DragonMake` represent individual components of your package.
 
 These include things like a Tweak, Preferences, etc.
 
-.. code-block:: YAML 
+.. code-block:: YAML
 
    DemoTweak:
      type: tweak
@@ -147,7 +147,7 @@ The "Important" Variables
      - List
      - List of files in the project to be compiled
 
-Types 
+Types
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
@@ -177,17 +177,17 @@ Types
      - Module containing only a stage variable
 
 
-Tweak bundle filters 
+Tweak bundle filters
 ^^^^^^^^^^^^^^^^^^^^^
 Bundle filters tell MobileSubstrate what processes to inject your tweak into.
 
-dragon supports the standard theos format, but allows specifying the values in the `DragonMake`, if you want. 
+dragon supports the standard theos format, but allows specifying the values in the `DragonMake`, if you want.
 
-.. code-block:: YAML 
+.. code-block:: YAML
 
    DemoTweak:
      type: tweak
-     # This bit 
+     # This bit
      filter:
        executables:
          - SpringBoard
@@ -196,7 +196,7 @@ dragon supports the standard theos format, but allows specifying the values in t
        - DemoTweak.x
 
 
-.. 
+..
    todo: info about files: stuff
 
 

--- a/docs/source/dragonmake.rst
+++ b/docs/source/dragonmake.rst
@@ -261,4 +261,3 @@ Setting Module Defaults
 A special module can be specified with the name `all:`; its variables will be set as the "default" value for all Modules in the project.
 
 If a Module specifies a different value than `all:`, it'll override the one declared in `all:`.
-

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,4 +46,5 @@ Since dragon was written in 'python', a language written for programming, adding
    commands
    quickstart
    dragonmake
+   structure
    theos

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,12 +4,12 @@ dragon
 
 "dragon" is a build system primarily targeting jailbroken iOS devices, capable of building tweaks, preferences, frameworks, apps, and anything else related to them.
 
-it's designed to be simple, both in installation and usage, and to be hackable and configurable at every step of the way.
+It's designed to be simple, both in installation and usage, and to be hackable and configurable at every step of the way.
 
 Benifits over "theos"
 ---------------------------------
 
-**Note:** `dragon is currently maintained by a single developer. while thorough testing is done, and dragon can run perfectly fine without theos, it's reccomended that you keep theos installed if you've already installed it. Theos has the advantage of long-term stability, being maintained by a team of developers for the past decade.`
+**Note:** `dragon is currently maintained by a single developer. while thorough testing is done, and dragon can run perfectly fine without Theos, it's reccomended that you keep Theos installed if you've already installed it. Theos has the advantage of long-term stability, as it has been maintained by a team of developers for more than a decade.`
 
 
 Speed
@@ -27,7 +27,7 @@ For an average project on an average PC, dragon typically takes **less than a se
 Simplicity
 *********************************
 
-Instead of "submodules" each having their own "Makefile" like in theos, the DragonMake format contains all of the build variables in a single file, at the root of a project.
+Instead of "submodules" each having their own "Makefile" like in theos, the DragonMake format contains all of the build variables in a single file at the root of a project.
 
 Manually writing, adding to, modifying, or hacking things together in a DragonMake file is simple and much more readable.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,22 +12,22 @@ Benifits over "theos"
 **Note:** `dragon is currently maintained by a single developer. while thorough testing is done, and dragon can run perfectly fine without theos, it's reccomended that you keep theos installed if you've already installed it. Theos has the advantage of long-term stability, being maintained by a team of developers for the past decade.`
 
 
-Speed 
+Speed
 *********************************
 
-Theos is unfortunately (in its current state) burdened by being written as a complex network of Makefiles, each importing one-another 
+Theos is unfortunately (in its current state) burdened by being written as a complex network of Makefiles, each importing one-another
 
-On systems with slow implementations of GNU Make, the slowdown can be immense. 
+On systems with slow implementations of GNU Make, the slowdown can be immense.
 
 dragon consists of a quick set of python scripts, and uses ninja for building. This can result in absurd speedups, especially with larger projects.
 
 For an average project on an average PC, dragon typically takes **less than a second** to compile a package.
 
 
-Simplicity 
+Simplicity
 *********************************
 
-Instead of "submodules" each having their own "Makefile" like in theos, the DragonMake format contains all of the build variables in a single file, at the root of a project. 
+Instead of "submodules" each having their own "Makefile" like in theos, the DragonMake format contains all of the build variables in a single file, at the root of a project.
 
 Manually writing, adding to, modifying, or hacking things together in a DragonMake file is simple and much more readable.
 
@@ -46,4 +46,4 @@ Since dragon was written in 'python', a language written for programming, adding
    commands
    quickstart
    dragonmake
-   theos 
+   theos

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -28,6 +28,11 @@ You can do both of these at the same time; most commands in dragon can be combin
 
     dragon b i
 
+
+Or you can use the shorthand notation::
+
+    dragon do
+
 Building and installing to the iOS Simulator::
 
     dragon b i sim

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -15,17 +15,17 @@ This opens the dragon project editor
 
 
 Building your project::
-    
+
     dragon b
 
 
 Installing your project::
 
-    dragon i 
+    dragon i
 
 
 You can do both of these at the same time; most commands in dragon can be combined::
-    
+
     dragon b i
 
 Building and installing to the iOS Simulator::

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -1,25 +1,24 @@
 Setup
 ---------------------
 
-Installing 
+Installing
 *********************
 
 Installing is incredibly simple::
 
-    pip3 install dragon 
+    pip3 install dragon
 
-Type "dragon" in your terminal to complete the initial setup 
+Type "dragon" in your terminal to complete the initial setup
 
 Updating
 *********************
 
 Versions 1.6.0 and later::
-    
+
     dragon update
 
 Updating from earlier versions::
-    
-    rm -rf ~/.dragon 
-    pip3 install --force-reinstall dragon 
-    dragon 
-    
+
+    rm -rf ~/.dragon
+    pip3 install --force-reinstall dragon
+    dragon

--- a/docs/source/structure.rst
+++ b/docs/source/structure.rst
@@ -1,0 +1,21 @@
+Structure
+---------------------
+
+dragon is set up such that the resources you need are provided via submodules and additional resources can be added as desired.
+
+frameworks/:
+    A place for frameworks (.framework) [uses .tbd format]
+include/:
+    A place for headers (.h)
+internal/:
+    A place for YAML configuration files (.yml) [not meant to be edited]
+lib/:
+    A place for libraries [uses .dylib or .tbd format]
+sdks/:
+    A place for SDKs (.sdk) [should be patched to include private frameworks]
+src/:
+    A place for out-sourced tools modified and built for use with dragon
+toolchain/:
+    A place for a user-provided toolchain [unnecessary on Darwin platforms]
+vendor/:
+    A place for tools and resources provided by dragon [not meant to be edited]

--- a/docs/source/theos.rst
+++ b/docs/source/theos.rst
@@ -4,7 +4,7 @@ Theos Support
 dragon aims to provide as much compatibility with theos projects and their structure as possible.
 
 
-"control" files, Bundle filters, etc.
+*control* files, Bundle filters, etc.
 =====================
 
 dragon ships with support for these in both Theos Makefile and DragonMake format projects.
@@ -15,10 +15,10 @@ Makefile interpreter
 
 dragon includes a best-effort Makefile "interpreter" that attempts to translate as much from standard Theos project structure as possible.
 
-It also includes several support files used with theos projects.
+It also includes several support files used with Theos projects.
 
-Compiling a theos project should be as simple as::
+Compiling a Theos project should be as simple as::
 
     dragon b
 
-If you encounter any issues with it, feel free to file an issue on https://github.com/DragonBuild/dragon .
+If you encounter any issues with it, feel free to file an issue on https://github.com/DragonBuild/dragon.

--- a/docs/source/theos.rst
+++ b/docs/source/theos.rst
@@ -22,4 +22,3 @@ Compiling a theos project should be as simple as::
     dragon b
 
 If you encounter any issues with it, feel free to file an issue on https://github.com/DragonBuild/dragon .
-

--- a/docs/table_generator.py
+++ b/docs/table_generator.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env python3
+
 '''
 Quick rST syntax table generator i threw together
 '''
 
 while True:
-
     size = int(input('Size > '))
 
     fields = []


### PR DESCRIPTION
## Changes
- Creates `structure.rst`
- Adjusts a handful of minor things
- Bumps docs deps

## Other
I made a handful of pull requests to dragon's subprojects a little while back adding and/or updating items. While doing that, I noticed a couple of odd placements I was curious about:
- In DragonBuild/src, `dm.pl` and `logos` are both regular directories instead of submodules. I know this is the case for the other projects in that repo as they have been modified, but I don't believe either of the aforementioned tools have been from their respective upstreams. If they are indeed unedited, I feel like it may more sense for them to be moved to DragonBuild/vendor (and made submodules for future-proofing).

- In DragonBuild/vendor, the headers provided in ./include appear to be identical to those in DragonBuild/include. Should they be removed from vendor and left in ~/.dragon/include? Or should they remain in vendor and be removed from ~/.dragon/include. If you're thinking the latter, the contents of the frameworks and libs directories should likely also be moved so they can be designated solely for user additions.