### PR TITLE
Update wizard + submodules

### DIFF
--- a/docs/source/structure.rst
+++ b/docs/source/structure.rst
@@ -17,5 +17,3 @@ src/:
     A place for out-sourced tools modified and built for use with dragon
 toolchain/:
     A place for a user-provided toolchain [unnecessary on Darwin platforms]
-vendor/:
-    A place for tools and resources provided by dragon [not meant to be edited]

--- a/src/dragon/config/defaults.yml
+++ b/src/dragon/config/defaults.yml
@@ -35,7 +35,7 @@ Defaults:
   additional_lib_dirs:
   additional_fw_dirs:
   prefix: []
-  cinclude: '-I$dragon_root_dir/include -I$dragon_root_dir/vendor/include -I$dragon_root_dir/include/_fallback -I$dragon_root_dir/headers/ -I$pwd'
+  cinclude: '-I$dragon_root_dir/include -I$dragon_root_dir/include/_fallback -I$dragon_root_dir/headers/ -I$pwd'
   stagedir: '_'
   modulesinternal: '-fmodules -fcxx-modules -fmodule-name=$name -fbuild-session-file=$dragon_data_dir/modules/ -fmodules-validate-once-per-build-session -fmodules-prune-after=345600 -fmodules-prune-interval=86400'
 

--- a/src/dragon/wizard.py
+++ b/src/dragon/wizard.py
@@ -28,7 +28,7 @@ def setup_wizard():
 
     os.chdir(dragon_root_dir)
 
-    for repo in ('lib', 'include', 'frameworks', 'vendor', 'sdks', 'src'):
+    for repo in ('lib', 'include', 'frameworks', 'sdks', 'src'):
         try:
             get_supporting(
                 f'https://api.github.com/repos/DragonBuild/{repo}/releases/latest',

--- a/src/dragon/wizard.py
+++ b/src/dragon/wizard.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-import json, os, shutil, ssl, sys, tarfile
-from ruyaml import YAML
-from urllib import request
+import os, shutil, sys
 from .util import deployable_path
 
 
@@ -29,20 +27,15 @@ def setup_wizard():
     os.chdir(dragon_root_dir)
 
     for repo in ('lib', 'include', 'frameworks', 'sdks', 'src'):
-        try:
-            get_supporting(
-                f'https://api.github.com/repos/DragonBuild/{repo}/releases/latest',
-                repo
-            )
-        except Exception as ex:
-            log(ex)
-            log('Potentially ratelimited, attempting fallback by cloning repo (this adds some overhead)')
-            if os.path.isdir(f'{repo}') and os.path.isdir(f'{repo}/.git'):
-                os.chdir(f'{repo}')
-                os.system('git pull origin $(git rev-parse --abbrev-ref HEAD)')
-                os.chdir(dragon_root_dir)
-            else:
-                os.system(f'git clone --depth=1 https://github.com/dragonbuild/{repo}')
+        if os.path.isdir(f'{repo}') and not os.path.isdir(f'{repo}/.git'):
+            shutil.rmtree(f'{repo}')
+            os.system(f'git clone --depth=1 --recursive https://github.com/DragonBuild/{repo}')
+        elif os.path.isdir(f'{repo}') and os.path.isdir(f'{repo}/.git'):
+            os.chdir(f'{repo}')
+            os.system('git pull origin $(git rev-parse --abbrev-ref HEAD)')
+            os.chdir(dragon_root_dir)
+        else:
+            os.system(f'git clone --depth=1 --recursive https://github.com/DragonBuild/{repo}')
 
     log('Deploying internal configuration')
     try:
@@ -56,43 +49,6 @@ def setup_wizard():
     except FileExistsError:
         pass
     log('Done!')
-
-
-def get_supporting(api: str, destination: str):
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE  # python doesn't bundle certs on macOS, so we have to disable SSL :)
-    response: dict = json.load(request.urlopen(api, context=ctx))
-    if os.path.exists(f'{destination}/metadata.yml'):
-        with open(f'{destination}/metadata.yml', 'r') as fd:
-            yaml=YAML(typ='safe')  # default, if not specfied, is 'rt' (round-trip)
-            metadata = yaml.load(fd)
-            version = metadata['version']
-            if version == response['tag_name']:
-                log(f'Latest {destination} already installed')
-                return
-    tar_url = response['tarball_url']
-
-    try:
-        shutil.rmtree(f'./{destination}')
-    except FileNotFoundError:
-        pass
-
-    log(f'Updating supporting {destination} v{response["tag_name"]} from {tar_url} ...')
-    tar_bytes = request.urlopen(tar_url, context=ctx).read()
-
-    fname = 'tmp.tar.gz'
-    with open(fname, 'wb') as f:
-        f.write(tar_bytes)
-
-    tar = tarfile.open(fname)
-    extracted_name = tar.members[0].name
-
-    log(f'Extracting into {os.environ["DRAGON_ROOT_DIR"] + destination}')
-    tar.extractall()
-    os.rename(extracted_name, destination)
-    os.remove(fname)
-
 
 if __name__ == '__main__':
     setup_wizard()

--- a/src/dragon/wizard.py
+++ b/src/dragon/wizard.py
@@ -9,12 +9,6 @@ def log(s: str, end: str = '\n') -> None:
     sys.stderr.flush()
 
 
-def get_input(prompt: str, default: str) -> str:
-    log(f'{prompt} ({default})', end='\n> ')
-    ret = input()
-    return ret if ret.strip() else default
-
-
 def setup_wizard():
     log(f'installing dragon v{os.environ["DRAGON_VERS"]}')
     log('=========================', end='\n\n')
@@ -27,11 +21,11 @@ def setup_wizard():
     os.chdir(dragon_root_dir)
 
     for repo in ('lib', 'include', 'frameworks', 'sdks', 'src'):
-        if os.path.isdir(f'{repo}') and not os.path.isdir(f'{repo}/.git'):
-            shutil.rmtree(f'{repo}')
+        if os.path.isdir(repo) and not os.path.isdir(f'{repo}/.git'):
+            shutil.rmtree(repo)
             os.system(f'git clone --depth=1 --recursive https://github.com/DragonBuild/{repo}')
-        elif os.path.isdir(f'{repo}') and os.path.isdir(f'{repo}/.git'):
-            os.chdir(f'{repo}')
+        elif os.path.isdir(repo) and os.path.isdir(f'{repo}/.git'):
+            os.chdir(repo)
             os.system('git pull origin $(git rev-parse --abbrev-ref HEAD)')
             os.chdir(dragon_root_dir)
         else:
@@ -49,6 +43,7 @@ def setup_wizard():
     except FileExistsError:
         pass
     log('Done!')
+
 
 if __name__ == '__main__':
     setup_wizard()


### PR DESCRIPTION
Changes:
- Removes `vendor`
  - `dm.pl` and `include` from here are duplicates of existing items in `src`
- Updates wizard to rely on git repos instead of api tarballs 
  - This allows for 
    - Submodule use 
    - Ease of updating
      - Will now git pull if existing repo
      - Remove + clone if old metadata-based repo
      - Clone if new 
  - Removes reliance on `{repo}/metadata.yml`

Tested briefly, but if this looks promising, please review before merging