### PR TITLE
Adjust main workflow and add pr-specific workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,17 +1,10 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: tests
+name: Main Repo Tests
 
 on:
   push:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-    branches:
-      - master
-      - 'dev/**'
-  pull_request:
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -1,0 +1,56 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Pr Repo Tests
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        project-link:
+          - https://github.com/kritanta-ios-tweaks/Chapters
+          - https://github.com/kritanta-ios-tweaks/Pivot
+          - https://github.com/kritanta-ios-tweaks/Shakelight
+          - https://github.com/kritanta-ios-tweaks/Gravitation
+          - https://github.com/kritanta-ios-tweaks/Signe
+          - https://github.com/kritanta-ios-tweaks/StatusViz
+          - https://github.com/kritanta-ios-tweaks/DeadRinger
+
+    runs-on: macos-latest
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if ! [[ -z "${{ github.event.pull_request.head.repo.full_name }}" ]]; then
+          # forked repo
+          pip install "git+https://github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.ref }}"
+        else
+          # branch
+          pip install "git+https://github.com/dragonbuild/dragon@${{ github.head_ref }}"
+        fi
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Install dragon
+      run: |
+        dragon
+
+    - name: Clone project
+      run: |
+        git init .
+        git remote add origin ${{ matrix.project-link }}
+        git pull origin $(git remote show origin | grep "HEAD branch" | sed 's/.*: //')
+
+    - name: Build project
+      run: |
+        dragon c b


### PR DESCRIPTION
Previously, pr's would run the test suite on the github repo. This is unhelpful as the changes proposed were not validated. Now, we have a main workflow for pushes to the repo that tests the repo in its current state and a prs workflow that tests the repo either from branches or forks. 