### PR TITLE
Update linking opts

### DIFF
--- a/src/dragon/config/defaults.yml
+++ b/src/dragon/config/defaults.yml
@@ -52,7 +52,6 @@ InternalDefaults:
   internalldflags: '$internalcflags $typeldflags $frameworks $libs $libflags $lopts $libSearch $ldflags $libs'
   internalsigntarget: '$signdir/$build_target_file.unsigned'
   internalsymtarget: '$signdir/$build_target_file.unsym'
-  internallibflags: '-lobjc -lc++'
   pwd: '.'
 
 # Applied on top of both of these.

--- a/src/dragon/config/targets.yml
+++ b/src/dragon/config/targets.yml
@@ -14,7 +14,7 @@ Targets:
   ios:
     all:
       targetos: iphoneos
-      targetvers: 10.0
+      targetvers: 9.0
       triple: arm64-apple-ios$targetvers
       arc: true
       sysroot: $dragon_root_dir/sdks/iPhoneOS.sdk

--- a/src/dragon/config/types.yml
+++ b/src/dragon/config/types.yml
@@ -19,10 +19,9 @@ Types:
     variables:
       install_location: '/Library/MobileSubstrate/DynamicLibraries/'
       build_target_file: '$dragon_data_dir/$stagedir/$location$name.dylib'
-      lopts: '-dynamiclib -ggdb -Xlinker -segalign -Xlinker 4000 -framework CydiaSubstrate'
+      lopts: '-dynamiclib -ggdb -framework CydiaSubstrate'
       frameworks:
         - UIKit
-        - Foundation
       stage2:
         - 'cp $name.plist $dragon_data_dir/_/Library/MobileSubstrate/DynamicLibraries/$name.plist 2>/dev/null  || python3 -m dragongen.bfilter $dragon_data_dir/DragonMake $name > $dragon_data_dir/_/Library/MobileSubstrate/DynamicLibraries/$name.plist'
   prefs:
@@ -34,7 +33,6 @@ Types:
       lopts: '-dynamiclib -ggdb -framework Preferences'
       frameworks:
         - UIKit
-        - Foundation
       stage2:
         - 'mkdir -p $dragon_data_dir/_/Library/PreferenceLoader/Preferences/'
         - 'cp entry.plist $dragon_data_dir/_/Library/PreferenceLoader/Preferences/$name.plist 2> /dev/null'
@@ -46,7 +44,6 @@ Types:
       lopts: '-dynamiclib -ggdb'
       frameworks:
         - UIKit
-        - Foundation
       stage2:
         - 'cp -R Resources/ $dragon_data_dir/$stagedir/$location/$name.bundle/'
 
@@ -69,12 +66,6 @@ Types:
     variables:
       install_location: '/Library/$name/$name.bundle/'
       build_target_file: 'build.ninja'
-      libs:
-        - 'substrate'
-      lopts: '-dynamiclib -ggdb'
-      frameworks:
-        - UIKit
-        - Foundation
       stage2:
         - 'true;'
   stage:

--- a/src/dragongen/generation.py
+++ b/src/dragongen/generation.py
@@ -293,7 +293,6 @@ class Generator(object):
                     build_state.append(Build(f'$builddir/logos/{name}.mm', 'logos', f))
                     filedict.setdefault('objcxx_files', [])
                     filedict['objcxx_files'].append(f'$builddir/logos/{name}.mm')
-                    linker_conds.add('-lc++')
 
         # Deal with compilation
         for a in self.project_variables['archs']:
@@ -308,9 +307,8 @@ class Generator(object):
                     build_state.append(Build(f'$builddir/{a}/{name}.o', ruleid, f))
 
                     LINKER_FLAGS = {  # Don't link objc/cpp if not needed
-                        'cxx': ['-lc++'],
                         'objc': ['-lobjc'],
-                        'objcxx': ['-lobjc', '-lc++'],
+                        'objcxx': ['-lobjc'],
                     }
                     if ftype in LINKER_FLAGS:
                         for flag in LINKER_FLAGS[ftype]:

--- a/src/dragongen/generation.py
+++ b/src/dragongen/generation.py
@@ -312,7 +312,7 @@ class Generator(object):
                     arch_specific_object_files.append(f'$builddir/{a}/{name}.o')
                     build_state.append(Build(f'$builddir/{a}/{name}.o', ruleid, f))
 
-                    LINKER_FLAGS = {  # Don't link objc/cpp if not needed
+                    LINKER_FLAGS = {  # Don't link objc if not needed
                         'objc': ['-lobjc'],
                         'objcxx': ['-lobjc'],
                     }

--- a/src/dragongen/generation.py
+++ b/src/dragongen/generation.py
@@ -295,7 +295,13 @@ class Generator(object):
                     filedict['objcxx_files'].append(f'$builddir/logos/{name}.mm')
 
         # Deal with compilation
-        for a in self.project_variables['archs']:
+        archs = self.project_variables['archs']
+        if any(x in ['armv6', 'armv7', 'armv7s'] for x in archs):
+            # https://twitter.com/saurik/status/654198997024796672
+            # iOS 9+ 32-bit pagesize on 64-bit CPUs changed to 16384 bytes from 4096
+            linker_conds.add("-Xlinker -segalign -Xlinker 4000")
+
+        for a in archs:
             arch_specific_object_files = []
 
             for ftype in (f for f in FILE_RULES if FILE_RULES[f] is not None and f in filedict):


### PR DESCRIPTION
- Removed superfluous libc++ links 
  - Handled automatically by cxx
- Removed unused internallibflags
- Dropped target vers to 9.0 as 8.0 doesn't support ARC properly anymore (libarclite_*.a missing???) and might as well do 9+ if we can
- Moved 32-bit linker fix to generator.py as it isn't necessary for all archs 
- Removes Foundation link if UIKit also present
  - UIKit depends on Foundation 
- Removed code options from `resource-bundle` type as it is expected to be exclusively resource files (?)
