### PR TITLE
Switch `ld` to `cxx` only for ++ files

### DIFF
--- a/src/dragongen/generation.py
+++ b/src/dragongen/generation.py
@@ -280,6 +280,10 @@ class Generator(object):
         filedict = classify({key: self.project_variables[key] for key in FILE_RULES})
         linker_conds = set()
 
+        # switch to cxx for pp files (auto-links ++ stdlib)
+        if any("cxx" in ftype for ftype in filedict):
+            self.project_variables["ld"] = self.project_variables["cxx"]
+
         # Deal with logos preprocessing
         if 'logos_files' in filedict:
             for f in standardize_file_list(subdir, filedict['logos_files']):
@@ -295,6 +299,8 @@ class Generator(object):
                     build_state.append(Build(f'$builddir/logos/{name}.mm', 'logos', f))
                     filedict.setdefault('objcxx_files', [])
                     filedict['objcxx_files'].append(f'$builddir/logos/{name}.mm')
+                    # switch to cxx for pp files (auto-links ++ stdlib)
+                    self.project_variables["ld"] = self.project_variables["cxx"]
 
         # Deal with compilation
         archs = self.project_variables['archs']

--- a/src/dragongen/toolchain.py
+++ b/src/dragongen/toolchain.py
@@ -42,10 +42,10 @@ class Toolchain:
                 return None
 
         tc = cls()
-        tc.ass = tc_dir + 'clang'
         tc.clang = tc_dir + 'clang'
         tc.clangpp = tc_dir + 'clang++'
-        tc.ld = tc_dir + 'clang++'
+        tc.ass = tc.clang
+        tc.ld = tc.clang
         tc.codesign = 'ldid'
         tc.dsym = tc_dir + 'dsymutil'
         # FIXME: hardcoded while I wait on a real distribution of llvm-objcs
@@ -70,10 +70,10 @@ class Toolchain:
             return None
 
         tc = cls()
-        tc.ass = tc_dir + 'clang'
         tc.clang = tc_dir + 'clang'
         tc.clangpp = tc_dir + 'clang++'
-        tc.ld = tc_dir + 'clang++'
+        tc.ass = tc.clang
+        tc.ld = tc.clang
         tc.codesign = tc_dir + 'ldid'
         tc.dsym = tc_dir + 'dsymutil'
         tc.lipo = tc_dir + 'lipo'


### PR DESCRIPTION
Defaults to cc now to prevent unnecessary link to ++ stdlib