### PR TITLE
Theos support updates

### DIFF
--- a/src/dragon/config/types.yml
+++ b/src/dragon/config/types.yml
@@ -6,13 +6,13 @@ Types:
       install_location: '/Applications'
       build_target_file: '$dragon_data_dir/$stagedir$location/$name.app/$name'
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.app/'
+        - 'cp -R $resource_dir/* $dragon_data_dir/$stagedir$location/$name.app/'
   application:
     variables:
       install_location: '/Applications'
       build_target_file: '$dragon_data_dir/$stagedir$location/$name.app/$name'
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.app/'
+        - 'cp -R $resource_dir/* $dragon_data_dir/$stagedir$location/$name.app/'
   tweak-jailed:
     variables:
       install_location: '/Applications'
@@ -20,7 +20,7 @@ Types:
       embed-libs:
         - CydiaSubstrate
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.app/'
+        - 'cp -R $resource_dir/* $dragon_data_dir/$stagedir$location/$name.app/'
   tweak:
     variables:
       install_location: '/Library/MobileSubstrate/DynamicLibraries'
@@ -44,7 +44,7 @@ Types:
       stage2:
         - 'mkdir -p $dragon_data_dir/$stagedir/Library/PreferenceLoader/Preferences/'
         - 'cp entry.plist $dragon_data_dir/stagedir/Library/PreferenceLoader/Preferences/$name.plist 2> /dev/null'
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.bundle'
+        - 'cp -R $resource_dir/* $dragon_data_dir/$stagedir$location/$name.bundle'
   bundle:
     variables:
       install_location: '/Library'
@@ -54,7 +54,7 @@ Types:
       frameworks:
         - UIKit
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.bundle/'
+        - 'cp -R $resource_dir/* $dragon_data_dir/$stagedir$location/$name.bundle/'
   resource-bundle:
     variables:
       install_location: '/Library/$name/$name.bundle/'
@@ -71,7 +71,7 @@ Types:
       frameworks:
         - Foundation
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.framework'
+        - 'cp -R $resource_dir/* $dragon_data_dir/$stagedir$location/$name.framework'
         - 'cp -R $dragon_data_dir/$stagedir$location/$name.framework $dragon_root_dir/frameworks/$name.framework'
         - 'if ! [ -z "$public_headers" ]; then
            mkdir -p $dragon_data_dir/$stagedir$location/$name.framework/Headers;

--- a/src/dragon/config/types.yml
+++ b/src/dragon/config/types.yml
@@ -3,58 +3,58 @@ Types:
   comprehensive:
   app:
     variables:
-      install_location: '/Applications/'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name.app/$name'
+      install_location: '/Applications'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.app/$name'
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir/$location/$name.app/'
+        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.app/'
   application:
     variables:
-      install_location: '/Applications/'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name.app/$name'
+      install_location: '/Applications'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.app/$name'
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir/$location/$name.app/'
+        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.app/'
   tweak-jailed:
     variables:
-      install_location: '/Applications/'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name.app/$name'
+      install_location: '/Applications'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.app/$name'
       embed-libs:
         - CydiaSubstrate
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir/$location/$name.app/'
+        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.app/'
   tweak:
     variables:
-      install_location: '/Library/MobileSubstrate/DynamicLibraries/'
-      build_target_file: '$dragon_data_dir/$stagedir/$location$name.dylib'
+      install_location: '/Library/MobileSubstrate/DynamicLibraries'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.dylib'
       lopts: '-dynamiclib -ggdb -framework CydiaSubstrate'
       ldflags: '-install_name @rpath/$name.dylib'
       frameworks:
         - UIKit
       stage2:
-        - 'cp $name.plist $dragon_data_dir/_/Library/MobileSubstrate/DynamicLibraries/$name.plist 2>/dev/null  || python3 -m dragongen.bfilter $dragon_data_dir/DragonMake $name > $dragon_data_dir/_/Library/MobileSubstrate/DynamicLibraries/$name.plist'
+        - 'cp $name.plist $dragon_data_dir/$stagedir$location/$name.plist 2>/dev/null  || python3 -m dragongen.bfilter $dragon_data_dir/DragonMake $name > $dragon_data_dir/$stagedir$location/$name.plist'
   prefs:
     variables:
-      install_location: '/Library/PreferenceBundles/$name.bundle'
-      build_target_file: '$dragon_data_dir/$stagedir$location/$name'
+      install_location: '/Library/PreferenceBundles'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.bundle/$name'
       libs:
         - 'substrate'
       lopts: '-dynamiclib -ggdb -framework Preferences'
-      ldflags: '-install_name $install_location/$name'
+      ldflags: '-install_name $location/$name.bundle/$name'
       frameworks:
         - UIKit
       stage2:
-        - 'mkdir -p $dragon_data_dir/_/Library/PreferenceLoader/Preferences/'
-        - 'cp entry.plist $dragon_data_dir/_/Library/PreferenceLoader/Preferences/$name.plist 2> /dev/null'
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir/$location'
+        - 'mkdir -p $dragon_data_dir/$stagedir/Library/PreferenceLoader/Preferences/'
+        - 'cp entry.plist $dragon_data_dir/stagedir/Library/PreferenceLoader/Preferences/$name.plist 2> /dev/null'
+        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.bundle'
   bundle:
     variables:
-      install_location: '/Library/$name/'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name.bundle/$name'
+      install_location: '/Library'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.bundle/$name'
       lopts: '-dynamiclib -ggdb'
-      ldflags: '-install_name $install_location/$name.bundle/$name'
+      ldflags: '-install_name $location/$name.bundle/$name'
       frameworks:
         - UIKit
       stage2:
-        - 'cp -R Resources/ $dragon_data_dir/$stagedir/$location/$name.bundle/'
+        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.bundle/'
   resource-bundle:
     variables:
       install_location: '/Library/$name/$name.bundle/'
@@ -63,52 +63,52 @@ Types:
         - 'true;'
   framework:
     variables:
-      install_location: '/Library/Frameworks/$name.framework'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name'
+      install_location: '/Library/Frameworks'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.framework/$name'
       public_headers: '$dragon_root_dir/include/'
       lopts: '-dynamiclib -ggdb'
       ldflags: '-install_name @rpath/$name.framework/$name'
       frameworks:
         - Foundation
       stage2:
-        - 'cp -R Resources/* $dragon_data_dir/$stagedir/$location'
-        - 'cp -R $dragon_data_dir/$stagedir$location $dragon_root_dir/frameworks/$name.framework'
+        - 'cp -R Resources/* $dragon_data_dir/$stagedir$location/$name.framework'
+        - 'cp -R $dragon_data_dir/$stagedir$location/$name.framework $dragon_root_dir/frameworks/$name.framework'
         - 'if ! [ -z "$public_headers" ]; then
-           mkdir -p $dragon_data_dir/$stagedir/$location/Headers;
-           cp $public_headers $dragon_data_dir/$stagedir/$location/Headers;
+           mkdir -p $dragon_data_dir/$stagedir$location/$name.framework/Headers;
+           cp $public_headers $dragon_data_dir/$stagedir$location/$name.framework/Headers;
            fi'
   cli:
     variables:
-      install_location: '/usr/bin'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name'
+      install_location: '/usr/local/bin'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name'
       stage2:
         - 'true;'
   binary:
     variables:
-      install_location: '/usr/bin'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name'
+      install_location: '/usr/local/bin'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name'
       stage2:
         - 'true;'
   tool:
     variables:
-      install_location: '/usr/bin'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name'
+      install_location: '/usr/local/bin'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name'
       stage2:
         - 'true;'
   library:
     variables:
-      install_location: '/usr/lib'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name.dylib'
+      install_location: '/usr/local/lib'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.dylib'
       ldflags: '-install_name @rpath/$name.dylib'
       lopts: '-dynamiclib -ggdb'
       stage2:
-        - 'true;'
+        - 'cp $build_target_file $dragon_root_dir/lib/'
   static:
     variables:
-      install_location: '/usr/lib'
-      build_target_file: '$dragon_data_dir/$stagedir/$location/$name.a'
+      install_location: '/usr/local/lib'
+      build_target_file: '$dragon_data_dir/$stagedir$location/$name.a'
       stage2:
-        - 'true;'
+        - 'cp $build_target_file $dragon_root_dir/lib/'
   stage:
     variables:
       build_target_file: 'build.ninja'

--- a/src/dragongen/cliutils.py
+++ b/src/dragongen/cliutils.py
@@ -24,14 +24,12 @@ if __name__ == "__main__":
                 if 'Package' in data:
                     print(data['Package'])
                     exit(0)
-
-        if os.path.exists('layout/DEBIAN/control'):
+        elif os.path.exists('layout/DEBIAN/control'):
             with open('layout/DEBIAN/control') as fp:
                 data = ruyaml.safe_load(fp)
                 if 'Package' in data:
                     print(data['Package'])
                     exit(0)
-
         exit(1)
 
     if 'needsobjcs' in sys.argv[1]:

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -155,7 +155,7 @@ class TheosMakefile(Makefile):
         for included in self.includes:
             if 'tweak.mk' in included:
                 self.type = TheosMakefileType.TWEAK
-                self.module['frameworks'] = ['Foundation', 'UIKit']  # :/
+                self.module['frameworks'] = ['UIKit']  # :/
                 self.module['type'] = 'tweak'
             if 'aggregate.mk' in included:
                 self.has_subprojects = True

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -197,6 +197,8 @@ class TheosMakefile(Makefile):
                 self.module['frameworks'] += self.variables[variable].split(' ')
             elif variable.endswith('_EXTRA_FRAMEWORKS'):
                 self.module['frameworks'] += self.variables[variable].split(' ')
+            elif variable.endswith('_LIBRARIES'):
+                self.module['libs'] = self.variables[variable].split(' ')
             elif variable.endswith('_CFLAGS'):
                 self.module['cflags'] = self.variables[variable]
             elif variable.endswith('_CXXFLAGS'):
@@ -211,8 +213,8 @@ class TheosMakefile(Makefile):
                 if 'PreferenceBundles' in path:
                     self.module['type'] = 'prefs'
                     self.type = TheosMakefileType.PREFS
-            elif variable.endswith('_LIBRARIES'):
-                self.module['libs'] = self.variables[variable].split(' ')
+            elif variable.endswith('_LINKAGE_TYPE') and self.variables[variable] == 'static':
+                    self.module['type'] = 'static'
 
         if 'cflags' in self.module and '-fobjc-arc' in self.module['cflags']:
             arc = True

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -227,7 +227,9 @@ class TheosMakefile(Makefile):
                     self.module['targetvers'] = ver
 
             if variable == 'SYSROOT':
-                self.module['sysroot'] = self.variables[variable]
+                sysroot = self.variables[variable]
+                if os.path.exists(sysroot):
+                    self.module['sysroot'] = sysroot
 
         files = []
         if 'files' in self.module:

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -195,12 +195,16 @@ class TheosMakefile(Makefile):
                 self.module['frameworks'] = self.variables[variable].split(' ')
             elif variable.endswith('_PRIVATE_FRAMEWORKS'):
                 self.module['frameworks'] += self.variables[variable].split(' ')
+            elif variable.endswith('_EXTRA_FRAMEWORKS'):
+                self.module['frameworks'] += self.variables[variable].split(' ')
             elif variable.endswith('_CFLAGS'):
                 self.module['cflags'] = self.variables[variable]
             elif variable.endswith('_CXXFLAGS'):
                 self.module['cxxflags'] = self.variables[variable]
             elif variable.endswith('_LDFLAGS'):
                 self.module['ldflags'] = self.variables[variable]
+            elif variable.endswith('_CODESIGN_FLAGS'):
+                self.module['entflag'] = self.variables[variable]
             elif variable.endswith('_INSTALL_PATH'):
                 path = self.variables[variable]
                 self.module['install_location'] = path
@@ -209,6 +213,9 @@ class TheosMakefile(Makefile):
                     self.type = TheosMakefileType.PREFS
             elif variable.endswith('_LIBRARIES'):
                 self.module['libs'] = self.variables[variable].split(' ')
+
+        if 'cflags' in self.module and '-fobjc-arc' in self.module['cflags']:
+            arc = True
 
         files = []
         if 'files' in self.module:

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -247,9 +247,14 @@ class TheosMakefileProcessor:
         with open('Makefile', 'r') as makefile:
             self.root_makefile = TheosMakefile(makefile.read())
 
-        with open('control', 'r') as control:
-            yaml = YAML(typ='safe')  # default, if not specfied, is 'rt' (round-trip)
-            self.control = yaml.load(control)
+        if os.path.exists('control'):
+            with open('control', 'r') as control:
+                yaml = YAML(typ='safe')  # default, if not specfied, is 'rt' (round-trip)
+                self.control = yaml.load(control)
+        elif os.path.exists('layout/DEBIAN/control'):
+            with open('layout/DEBIAN/control', 'r') as control:
+                yaml = YAML(typ='safe')
+                self.control = yaml.load(control)
 
         self.project['name'] = self.control['Name']
 

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -135,6 +135,8 @@ class TheosMakefileType(Enum):
     LIBRARY = 2
     APPLICATION = 3
     FRAMEWORK = 4
+    TOOL = 5
+    PREFS = 6
 
 
 class TheosMakefile(Makefile):
@@ -158,7 +160,7 @@ class TheosMakefile(Makefile):
             if 'aggregate.mk' in included:
                 self.has_subprojects = True
             if 'bundle.mk' in included:
-                self.module['type'] = 'prefs'
+                self.module['type'] = 'bundle'
                 self.type = TheosMakefileType.BUNDLE
             if 'library.mk' in included:
                 self.module['type'] = 'library'
@@ -169,6 +171,9 @@ class TheosMakefile(Makefile):
             if 'framework.mk' in included:
                 self.module['type'] = 'framework'
                 self.type = TheosMakefileType.FRAMEWORK
+            if 'tool.mk' in included:
+                self.module['type'] = 'tool'
+                self.type = TheosMakefileType.TOOL
 
         for variable in self.variables:
             self.variables[variable] = self.variables[variable].replace('$(THEOS_STAGING_DIR)', '$dragon_data_dir/_')
@@ -194,9 +199,12 @@ class TheosMakefile(Makefile):
                 self.module['cxxflags'] = self.variables[variable]
             elif variable.endswith('_LDFLAGS'):
                 self.module['ldflags'] = self.variables[variable]
-            # This borks prefs installs # TODO: figure out why
-            # elif variable.endswith('_INSTALL_PATH'):
-            # self.module['install_location'] = self.variables[variable]
+            elif variable.endswith('_INSTALL_PATH'):
+                path = self.variables[variable]
+                self.module['install_location'] = path
+                if 'PreferenceBundles' in path:
+                    self.module['type'] = 'prefs'
+                    self.type = TheosMakefileType.PREFS
             elif variable.endswith('_LIBRARIES'):
                 self.module['libs'] = self.variables[variable].split(' ')
 

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -178,7 +178,9 @@ class TheosMakefile(Makefile):
             self.variables[variable] = self.variables[variable].replace('$(', '$$(')
             if variable == 'ARCHS':
                 self.module['archs'] = self.variables[variable].split(' ')
-            if variable.endswith('_NAME'):
+            elif variable == 'TARGET':
+                self.module['targetvers'] = self.variables[variable].split(':')[-1]
+            elif variable.endswith('_NAME'):
                 self.module_name = self.variables[variable]
             elif variable.endswith('_FILES'):
                 self.module['files'] = self.variables[variable].split(' ')

--- a/src/dragongen/theos.py
+++ b/src/dragongen/theos.py
@@ -184,7 +184,9 @@ class TheosMakefile(Makefile):
             if variable == 'ARCHS':
                 self.module['archs'] = self.variables[variable].split(' ')
             elif variable == 'TARGET':
-                self.module['targetvers'] = self.variables[variable].split(':')[-1]
+                ver = self.variables[variable].split(':')[-1]
+                if float(ver) >= 9.0:
+                    self.module['targetvers'] = ver
             elif variable.endswith('_NAME'):
                 self.module_name = self.variables[variable]
             elif variable.endswith('_FILES'):

--- a/src/dragongen/util.py
+++ b/src/dragongen/util.py
@@ -35,6 +35,7 @@ def classify(filedict: dict) -> dict:
     return {key: value for (key, value) in filedict.items() if value != []}
 
 
+# NOTE: currently unused; see src/dragongen/generation.py's main()
 # this was supposed to be a really small function, i dont know what happened ;-;
 def interpret_theos_makefile(file: object, root: object = True) -> dict:
     project = {}


### PR DESCRIPTION
Fixes #101 and #95 

Changes:
- Adds support for additional Theos vars
- Adjusts project type syntax (types.yml) to match Theos 
- Copies libs to ~/.dragon/lib on build to mimic frameworks
- Fixes all supported file types 
  -  Various Theos project types still fail (#102), but most of those are sparingly used
- Changes lib/bin install path to local instead of system
- Changes layout/DEBIAN/control check to be else if
- Fixes bundle install paths being treated as prefs
- More I'm probably forgetting 